### PR TITLE
Big bugs, with fixes

### DIFF
--- a/keyhunter.py
+++ b/keyhunter.py
@@ -72,7 +72,9 @@ def main():
                 pos = data.find(magic, pos)
                 if pos == -1:
                     break
-                print EncodeBase58Check('\x80' + data[pos+magiclen:pos+magiclen+32])
+                key_offset = pos + magiclen
+                key_data = "\x80" + data[key_offset:key_offset + 32]
+                print EncodeBase58Check(key_data)
                 pos += 1
 
             # are we at the end of the file?

--- a/keyhunter.py
+++ b/keyhunter.py
@@ -13,6 +13,7 @@ magiclen = len(magic)
 
 
 ##### start code from pywallet.py #############
+
 __b58chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 __b58base = len(__b58chars)
 
@@ -48,7 +49,6 @@ def EncodeBase58Check(secret):
     hash = Hash(secret)
     return b58encode(secret + hash[0:4])
 
-
 ########## end code from pywallet.py ############
 
 def main():
@@ -79,10 +79,6 @@ def main():
             if len(data) == readlength:
                 # make sure we didn't miss any keys at the end of the block
                 f.seek(f.tell() - (32 + magiclen))
-
-
-# code grabbed from pywallet.py
-
 
 if __name__ == "__main__":
     main()

--- a/keyhunter.py
+++ b/keyhunter.py
@@ -43,8 +43,9 @@ def b58encode(v):
     # leading 0-bytes in the input become leading-1s
     nPad = 0
     for c in v:
-        if c == '\0': nPad += 1
-        else: break
+        if c != '\0': 
+            break
+        nPad += 1
 
   return (__b58chars[0]*nPad) + result
 
@@ -66,22 +67,21 @@ while True:
         break
 
   # look in this block for keys
-    x=0
+    x = 0
     while True:
         # find the magic number
-        pos=data.find(magic,x)
-        #pos=data.find('\13\02\01\01\04\20',0)
-        if pos==-1:
+        pos = data.find(magic,x)
+        if pos == -1:
             break
-        print EncodeBase58Check('\x80'+data[pos+magiclen:pos+magiclen+32])
-        x+=(pos+1)
+        print EncodeBase58Check('\x80' + data[pos+magiclen:pos+magiclen+32])
+        x += (pos + 1)
 
   # are we at the end of the file?
     if len(data) < readlength:
         break
 
   # make sure we didn't miss any keys at the end of the block
-    f.seek(f.tell()-(32+magiclen))
+    f.seek(f.tell() - (32 + magiclen))
 
 # code grabbed from pywallet.py
 

--- a/keyhunter.py
+++ b/keyhunter.py
@@ -39,7 +39,7 @@ def b58encode(v):
         long_value = div
     result = __b58chars[long_value] + result
 
-  # Bitcoin does a little leading-zero-compression:
+    # Bitcoin does a little leading-zero-compression:
     # leading 0-bytes in the input become leading-1s
     nPad = 0
     for c in v:

--- a/keyhunter.py
+++ b/keyhunter.py
@@ -8,16 +8,8 @@ import sys
 # bytes to read at a time from file (10meg)
 readlength=10*1024*1024
 
-if len(sys.argv)!=2:
-    print "./keyhunter.py <filename>"
-    exit()
-
-filename = sys.argv[1]
-
-f = open(filename, "rb")
 magic = '\x01\x30\x82\x01\x13\x02\x01\x01\x04\x20'
 magiclen = len(magic)
-
 
 
 ##### start code from pywallet.py #############
@@ -28,11 +20,11 @@ def b58encode(v):
     """ encode v, which is a string of bytes, to base58.
     """
 
-  long_value = 0L
+    long_value = 0L
     for (i, c) in enumerate(v[::-1]):
         long_value += (256**i) * ord(c)
 
-  result = ''
+    result = ''
     while long_value >= __b58base:
         div, mod = divmod(long_value, __b58base)
         result = __b58chars[mod] + result
@@ -47,7 +39,7 @@ def b58encode(v):
             break
         nPad += 1
 
-  return (__b58chars[0]*nPad) + result
+    return (__b58chars[0]*nPad) + result
 
 def Hash(data):
     return hashlib.sha256(hashlib.sha256(data).digest()).digest()
@@ -59,28 +51,38 @@ def EncodeBase58Check(secret):
 
 ########## end code from pywallet.py ############
 
-# read through target file one block at a time
-while True:
-    data = f.read(readlength)
-    if not data:
-        break
+def main():
+    if len(sys.argv) != 2:
+        print "./{0} <filename>".format(sys.argv[0])
+        exit()
 
-    # look in this block for keys
-    pos = 0
-    while True:
-        # find the magic number
-        pos = data.find(magic, pos)
-        if pos == -1:
-            break
-        print EncodeBase58Check('\x80' + data[pos+magiclen:pos+magiclen+32])
-        pos += 1
+    filename = sys.argv[1]
 
-    # are we at the end of the file?
-    if len(data) == readlength:
-        # make sure we didn't miss any keys at the end of the block
-        f.seek(f.tell() - (32 + magiclen))
+    with open(filename, "rb") as f:
+        # read through target file one block at a time
+        while True:
+            data = f.read(readlength)
+            if not data:
+                break
+
+            # look in this block for keys
+            pos = 0
+            while True:
+                # find the magic number
+                pos = data.find(magic, pos)
+                if pos == -1:
+                    break
+                print EncodeBase58Check('\x80' + data[pos+magiclen:pos+magiclen+32])
+                pos += 1
+
+            # are we at the end of the file?
+            if len(data) == readlength:
+                # make sure we didn't miss any keys at the end of the block
+                f.seek(f.tell() - (32 + magiclen))
 
 
 # code grabbed from pywallet.py
 
 
+if __name__ == "__main__":
+    main()

--- a/keyhunter.py
+++ b/keyhunter.py
@@ -51,13 +51,8 @@ def EncodeBase58Check(secret):
 
 ########## end code from pywallet.py ############
 
-def main():
-    if len(sys.argv) != 2:
-        print "./{0} <filename>".format(sys.argv[0])
-        exit()
-
-    filename = sys.argv[1]
-
+def find_keys(filename):
+    keys = set()
     with open(filename, "rb") as f:
         # read through target file one block at a time
         while True:
@@ -74,13 +69,23 @@ def main():
                     break
                 key_offset = pos + magiclen
                 key_data = "\x80" + data[key_offset:key_offset + 32]
-                print EncodeBase58Check(key_data)
+                keys.add(EncodeBase58Check(key_data))
                 pos += 1
 
             # are we at the end of the file?
             if len(data) == readlength:
                 # make sure we didn't miss any keys at the end of the block
                 f.seek(f.tell() - (32 + magiclen))
+    return keys
+
+def main():
+    if len(sys.argv) != 2:
+        print "./{0} <filename>".format(sys.argv[0])
+        exit()
+
+    keys = find_keys(sys.argv[1])
+    for key in keys:
+        print key
 
 if __name__ == "__main__":
     main()

--- a/keyhunter.py
+++ b/keyhunter.py
@@ -9,8 +9,8 @@ import sys
 readlength=10*1024*1024
 
 if len(sys.argv)!=2:
-  print "./keyhunter.py <filename>"
-  exit()
+    print "./keyhunter.py <filename>"
+    exit()
 
 filename = sys.argv[1]
 
@@ -25,64 +25,63 @@ __b58chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 __b58base = len(__b58chars)
 
 def b58encode(v):
-  """ encode v, which is a string of bytes, to base58.
-  """
+    """ encode v, which is a string of bytes, to base58.
+    """
 
   long_value = 0L
-  for (i, c) in enumerate(v[::-1]):
-    long_value += (256**i) * ord(c)
+    for (i, c) in enumerate(v[::-1]):
+        long_value += (256**i) * ord(c)
 
   result = ''
-  while long_value >= __b58base:
-    div, mod = divmod(long_value, __b58base)
-    result = __b58chars[mod] + result
-    long_value = div
-  result = __b58chars[long_value] + result
+    while long_value >= __b58base:
+        div, mod = divmod(long_value, __b58base)
+        result = __b58chars[mod] + result
+        long_value = div
+    result = __b58chars[long_value] + result
 
   # Bitcoin does a little leading-zero-compression:
-  # leading 0-bytes in the input become leading-1s
-  nPad = 0
-  for c in v:
-    if c == '\0': nPad += 1
-    else: break
+    # leading 0-bytes in the input become leading-1s
+    nPad = 0
+    for c in v:
+        if c == '\0': nPad += 1
+        else: break
 
   return (__b58chars[0]*nPad) + result
 
 def Hash(data):
-  return hashlib.sha256(hashlib.sha256(data).digest()).digest()
+    return hashlib.sha256(hashlib.sha256(data).digest()).digest()
 
 def EncodeBase58Check(secret):
-  hash = Hash(secret)
-  return b58encode(secret + hash[0:4])
+    hash = Hash(secret)
+    return b58encode(secret + hash[0:4])
+
 
 ########## end code from pywallet.py ############
-
-
 
 # read through target file
 # one block at a time
 while True:
-  data = f.read(readlength)
-  if not data:
-    break
+    data = f.read(readlength)
+    if not data:
+        break
 
   # look in this block for keys
-  x=0
-  while True:
-    # find the magic number
-    pos=data.find(magic,x)
-    #pos=data.find('\13\02\01\01\04\20',0)
-    if pos==-1:
-      break
-    print EncodeBase58Check('\x80'+data[pos+magiclen:pos+magiclen+32])
-    x+=(pos+1)
-  
+    x=0
+    while True:
+        # find the magic number
+        pos=data.find(magic,x)
+        #pos=data.find('\13\02\01\01\04\20',0)
+        if pos==-1:
+            break
+        print EncodeBase58Check('\x80'+data[pos+magiclen:pos+magiclen+32])
+        x+=(pos+1)
+
   # are we at the end of the file?
-  if len(data) < readlength:
-    break
+    if len(data) < readlength:
+        break
 
   # make sure we didn't miss any keys at the end of the block
-  f.seek(f.tell()-(32+magiclen))
+    f.seek(f.tell()-(32+magiclen))
 
 # code grabbed from pywallet.py
 

--- a/keyhunter.py
+++ b/keyhunter.py
@@ -14,7 +14,7 @@ if len(sys.argv)!=2:
 
 filename = sys.argv[1]
 
-f = open(filename)
+f = open(filename, "rb")
 magic = '\x01\x30\x82\x01\x13\x02\x01\x01\x04\x20'
 magiclen = len(magic)
 

--- a/keyhunter.py
+++ b/keyhunter.py
@@ -59,29 +59,27 @@ def EncodeBase58Check(secret):
 
 ########## end code from pywallet.py ############
 
-# read through target file
-# one block at a time
+# read through target file one block at a time
 while True:
     data = f.read(readlength)
     if not data:
         break
 
-  # look in this block for keys
-    x = 0
+    # look in this block for keys
+    pos = 0
     while True:
         # find the magic number
-        pos = data.find(magic,x)
+        pos = data.find(magic, pos)
         if pos == -1:
             break
         print EncodeBase58Check('\x80' + data[pos+magiclen:pos+magiclen+32])
-        x += (pos + 1)
+        pos += 1
 
-  # are we at the end of the file?
-    if len(data) < readlength:
-        break
+    # are we at the end of the file?
+    if len(data) == readlength:
+        # make sure we didn't miss any keys at the end of the block
+        f.seek(f.tell() - (32 + magiclen))
 
-  # make sure we didn't miss any keys at the end of the block
-    f.seek(f.tell() - (32 + magiclen))
 
 # code grabbed from pywallet.py
 


### PR DESCRIPTION
This patch fixes a pretty big issue with large amounts of data being skipped.

The current script (incorrectly) assumes that the return value from str.find subtracts the offset position from the return value.

``` python
pos=data.find(magic,x)
```

Returns the offset of the magic string. The value returned is still the absolute offset, and does not take 'x' into account in any way. That would be fine, except for this line:

``` python
x+=(pos+1)
```

This increases the search offset by the position of the found string + 1.

Now lets say we have some private key at data offset 100, 150, and 200.

After the first discovery, pos would accurately be updated to '101' at the end. 

``` python
# x is still 0
x += (100+1)
```

Now when the second discovery happens, at offset 150, this happens again:

``` python
# x is now 101
x += (150+1)
```

Resulting in the new offset being 252, instead of 152.

This ends up erroneously skipping our third key entirely.

---

I also did a bit of cleanup:
- File open flags have been changed to "rb" (Windows can't find anything without it)
- Indentation changed to four spaces per tab
- Implemented a 'main' function
- Made key finding a function (for module reuse)
- Stole tabbek's idea of using 'with' for the open file
- Ignore duplicate keys
